### PR TITLE
Fix: docker path errors because of database version

### DIFF
--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on: 
       - db
   db:
-    image: postgres
+    image: postgres:17-alpine
     restart: always
     shm_size: 128mb
     env_file: ".env"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,12 @@ services:
     depends_on: 
       - db
   db:
-    image: postgres
+    image: postgres:17-alpine
     restart: always
     shm_size: 128mb
     env_file: ".env"
     volumes:
-      - ./postgres_data:/var/lib/postgresql/data
+      - ./postgres_data:/var/lib/postgresql
     ports:
       - 5432:5432
 


### PR DESCRIPTION
# Changelogs
- (ba27954) ci: set postgress-17-alpine as default database version - @OliYan-debug
